### PR TITLE
Eckelj/data consistency improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,37 @@ curl -X POST http://localhost:8080/register \
 curl http://localhost:8080/api/devices
 ```
 
+#### /api/energy
+- **Method:** POST
+- **Request Body:** JSON object with the following fields:
+  - `version` (int, required): Version of the payload format
+  - `zigbee_id` (string, required): Unique Zigbee ID for the device
+  - `date` (string, required): Date for the energy data (YYYY-MM-DD)
+  - `timezone_name` (string, required): Name of the timezone (e.g., "Europe/Vienna")
+  - `data` (array of 96 objects, required): Each object is:
+    - `value` (float): The energy value
+    - `timestamp` (string): UTC timestamp in the format `YYYY-MM-DD HH:MM:SS`
+- **Response:**
+  - On success: `{ "message": "Energy data received and written to database successfully" }`
+  - On error: `{ "error": "..." }` with appropriate HTTP status code (e.g., 400 for validation errors, 409 for duplicate, 500 for server error)
+
+**Example:**
+```json
+{
+  "version": 1,
+  "zigbee_id": "12345",
+  "date": "2025-06-04",
+  "timezone_name": "Europe/Vienna",
+  "data": [
+    { "value": 1.23, "timestamp": "2025-06-04 00:00:00" },
+    { "value": 1.24, "timestamp": "2025-06-04 00:15:00" },
+    ... (total 96 entries) ...
+  ]
+}
+```
+
+**Note:** The `data` array must contain exactly 96 entries, each with a value and a UTC timestamp string in the specified format.
+
 #### /api/energy/download
 - **Method:** GET
 - **Query Parameter:** `pwd` (required, must match the configured server password)

--- a/cmd/energy-db/main.go
+++ b/cmd/energy-db/main.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/syndtr/goleveldb/leveldb"
+)
+
+func main() {
+	dbDir := flag.String("db", "", "Path to the LevelDB database directory")
+	outFile := flag.String("out", "output.json", "Output JSON file")
+	flag.Parse()
+
+	if *dbDir == "" {
+		log.Fatal("Please provide the path to the LevelDB database directory using --db")
+	}
+
+	db, err := leveldb.OpenFile(*dbDir, nil)
+	if err != nil {
+		log.Fatalf("Failed to open LevelDB: %v", err)
+	}
+	defer db.Close()
+
+	iter := db.NewIterator(nil, nil)
+	defer iter.Release()
+
+	entries := make(map[string]string)
+	for iter.Next() {
+		key := string(iter.Key())
+		value := string(iter.Value())
+		entries[key] = value
+	}
+	if err := iter.Error(); err != nil {
+		log.Fatalf("Iterator error: %v", err)
+	}
+
+	file, err := os.Create(*outFile)
+	if err != nil {
+		log.Fatalf("Failed to create output file: %v", err)
+	}
+	defer file.Close()
+
+	enc := json.NewEncoder(file)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(entries); err != nil {
+		log.Fatalf("Failed to encode JSON: %v", err)
+	}
+
+	fmt.Printf("Exported %d entries to %s\n", len(entries), *outFile)
+}

--- a/internal/influxdb/influxdb.go
+++ b/internal/influxdb/influxdb.go
@@ -7,6 +7,13 @@ import (
 
 type Point interface{}
 
+type LastPointResult struct {
+	Timestamp time.Time
+	Fields    map[string]interface{}
+	Tags      map[string]string
+}
+
 type Client interface {
 	WritePoint(ctx context.Context, measurement string, tags map[string]string, fields map[string]interface{}, ts time.Time) error
+	GetLastPoint(ctx context.Context, measurement string, tags map[string]string) (*LastPointResult, error)
 }

--- a/internal/influxdb/localinfluxclient.go
+++ b/internal/influxdb/localinfluxclient.go
@@ -1,0 +1,80 @@
+package influxdb
+
+import (
+	"context"
+	"time"
+
+	influxdb2 "github.com/influxdata/influxdb-client-go"
+	"github.com/influxdata/influxdb-client-go/api"
+	"github.com/influxdata/influxdb-client-go/api/write"
+
+	_ "embed"
+)
+
+// LocalInfluxClient implements the influxdb.Client interface for both writing and querying
+// InfluxDB using the Go client.
+type LocalInfluxClient struct {
+	writeAPI api.WriteAPIBlocking
+	queryAPI api.QueryAPI
+	org      string
+	bucket   string
+}
+
+func NewLocalInfluxClient(client influxdb2.Client, org, bucket string) *LocalInfluxClient {
+	return &LocalInfluxClient{
+		writeAPI: client.WriteAPIBlocking(org, bucket),
+		queryAPI: client.QueryAPI(org),
+		org:      org,
+		bucket:   bucket,
+	}
+}
+
+func (c *LocalInfluxClient) WritePoint(ctx context.Context, measurement string, tags map[string]string, fields map[string]interface{}, ts time.Time) error {
+	return c.WritePointTyped(ctx, measurement, tags, fields, ts)
+}
+
+// WritePointTyped is the strongly-typed version used internally
+func (c *LocalInfluxClient) WritePointTyped(ctx context.Context, measurement string, tags map[string]string, fields map[string]interface{}, ts time.Time) error {
+	p := write.NewPoint(measurement, tags, fields, ts)
+	return c.writeAPI.WritePoint(ctx, p)
+}
+
+func (c *LocalInfluxClient) GetLastPoint(ctx context.Context, measurement string, tags map[string]string) (*LastPointResult, error) {
+	// Compose Flux query to get the last point for the given tags
+	flux := `from(bucket: "` + c.bucket + `")` +
+		`|> range(start: -30d)` +
+		`|> filter(fn: (r) => r["_measurement"] == "` + measurement + `"`
+	for k, v := range tags {
+		flux += ` and r["` + k + `"] == "` + v + `"`
+	}
+	flux += `)|> last()`
+	result, err := c.queryAPI.Query(ctx, flux)
+	if err != nil {
+		return nil, err
+	}
+	var last *LastPointResult
+	for result.Next() {
+		if last == nil {
+			last = &LastPointResult{
+				Fields: make(map[string]interface{}),
+				Tags:   make(map[string]string),
+			}
+		}
+		last.Timestamp = result.Record().Time()
+		last.Fields[result.Record().Field()] = result.Record().Value()
+		for k, v := range result.Record().Values() {
+			if k != "_value" && k != "_field" && k != "_time" {
+				if str, ok := v.(string); ok {
+					last.Tags[k] = str
+				}
+			}
+		}
+	}
+	if result.Err() != nil {
+		return nil, result.Err()
+	}
+	if last == nil {
+		return nil, nil // No data found
+	}
+	return last, nil
+}

--- a/internal/influxdb/mock.go
+++ b/internal/influxdb/mock.go
@@ -2,6 +2,7 @@ package influxdb
 
 import (
 	"context"
+	"time"
 
 	"github.com/stretchr/testify/mock"
 )
@@ -10,7 +11,15 @@ type MockClient struct {
 	mock.Mock
 }
 
-func (m *MockClient) WritePoint(ctx context.Context, measurement string, tags map[string]string, fields map[string]interface{}, ts interface{}) error {
+func (m *MockClient) WritePoint(ctx context.Context, measurement string, tags map[string]string, fields map[string]interface{}, ts time.Time) error {
 	args := m.Called(ctx, measurement, tags, fields, ts)
 	return args.Error(0)
+}
+
+func (m *MockClient) GetLastPoint(ctx context.Context, measurement string, tags map[string]string) (*LastPointResult, error) {
+	args := m.Called(ctx, measurement, tags)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*LastPointResult), args.Error(1)
 }

--- a/internal/model/energydata.go
+++ b/internal/model/energydata.go
@@ -1,16 +1,49 @@
 package model
 
-type EnergyData struct {
-	Version  int         `json:"version"`
-	ZigbeeID string      `json:"zigbee_id"`
-	Date     string      `json:"date"`
-	Data     [96]float64 `json:"data"`
+import (
+	"fmt"
+	"time"
+)
+
+type EnergyTuple struct {
+	Value     float64   `json:"value"`
+	Timestamp TimeStamp `json:"timestamp"`
 }
 
-// IsEnergyDataIncreasing checks if the Data array is monotonically non-decreasing
-func IsEnergyDataIncreasing(data [96]float64) bool {
+type TimeStamp time.Time
+
+const timeLayout = "2006-01-02 15:04:05"
+
+func (t TimeStamp) MarshalJSON() ([]byte, error) {
+	utc := time.Time(t).UTC()
+	return []byte(fmt.Sprintf("\"%s\"", utc.Format(timeLayout))), nil
+}
+
+func (t *TimeStamp) UnmarshalJSON(b []byte) error {
+	s := string(b)
+	if len(s) >= 2 && s[0] == '"' && s[len(s)-1] == '"' {
+		s = s[1 : len(s)-1]
+	}
+	tp, err := time.ParseInLocation(timeLayout, s, time.UTC)
+	if err != nil {
+		return err
+	}
+	*t = TimeStamp(tp)
+	return nil
+}
+
+type EnergyData struct {
+	Version      int             `json:"version"`
+	ZigbeeID     string          `json:"zigbee_id"`
+	Date         string          `json:"date"`
+	TimezoneName string          `json:"timezone_name"`
+	Data         [96]EnergyTuple `json:"data"`
+}
+
+// IsEnergyDataIncreasing checks if the Data array is monotonically non-decreasing by Value
+func IsEnergyDataIncreasing(data [96]EnergyTuple) bool {
 	for i := 1; i < len(data); i++ {
-		if data[i] < data[i-1] {
+		if data[i].Value < data[i-1].Value {
 			return false
 		}
 	}

--- a/internal/server/handler_energy.go
+++ b/internal/server/handler_energy.go
@@ -66,7 +66,7 @@ func (s *Server) handleEnergyData(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	// check if data is equal or increased
-	if energyData.Data[0].Value < lastPoints.Fields["kW/h"].(float64) {
+	if lastPoints != nil && energyData.Data[0].Value < lastPoints.Fields["kW/h"].(float64) {
 		sendJSONResponse(w, Response{Error: "Incompatible data: data does not increase."}, http.StatusConflict)
 		return
 	}

--- a/internal/server/handler_energy.go
+++ b/internal/server/handler_energy.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"context"
 	"encoding/json"
 	"log"
 	"net/http"
@@ -25,8 +26,6 @@ func (s *Server) handleEnergyData(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	log.Printf("Received energy data: %+v", energyData)
-
 	existsPlmnt, err := s.plmntClient.IsZigbeeRegistered(energyData.ZigbeeID)
 	if err != nil {
 		if strings.Contains(err.Error(), "not found") {
@@ -50,6 +49,25 @@ func (s *Server) handleEnergyData(w http.ResponseWriter, r *http.Request) {
 	}
 	if reportStatus != "" {
 		sendJSONResponse(w, Response{Error: "report for this ZigbeeID and date already exists"}, http.StatusConflict)
+		return
+	}
+
+	// get first data element from payload
+	// compare it against the last registered datapoint of this reporting device
+	lastPoints, err := s.influxDBClient.GetLastPoint(context.Background(),
+		"energy_data",
+		map[string]string{
+			"Inspelning": energyData.ZigbeeID,
+			"timezone":   energyData.TimezoneName,
+		})
+	if err != nil {
+		log.Printf("Failed to get last point from InfluxDB: %v", err)
+		sendJSONResponse(w, Response{Error: "Failed to retrieve last point from database"}, http.StatusInternalServerError)
+		return
+	}
+	// check if data is equal or increased
+	if energyData.Data[0].Value < lastPoints.Fields["kW/h"].(float64) {
+		sendJSONResponse(w, Response{Error: "Incompatible data: data does not increase."}, http.StatusConflict)
 		return
 	}
 

--- a/internal/server/handler_energy_test.go
+++ b/internal/server/handler_energy_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/rddl-network/energy-service/internal/config"
 	"github.com/rddl-network/energy-service/internal/database"
@@ -50,13 +51,23 @@ func TestHandleEnergyData_UnregisteredZigbeeID(t *testing.T) {
 	dbMock := &database.MockDatabase{}
 	// Mock IsZigbeeRegistered to return false for any zigbeeID except "registered123"
 	plmntMock.On("IsZigbeeRegistered", mock.Anything).Return(false, nil)
+	dbMock.On("SetReportStatus", "unregistered123", "2025-06-04", "valid").Return(nil)
+	influxMock.On("WritePoint", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 	_, mux := setupEnergyTestServer(t, plmntMock, influxMock, dbMock)
 
+	var data [96]model.EnergyTuple
+	for i := 0; i < 96; i++ {
+		data[i] = model.EnergyTuple{
+			Value:     0,
+			Timestamp: model.TimeStamp(time.Now().UTC()),
+		}
+	}
 	energy := model.EnergyData{
-		Version:  1,
-		ZigbeeID: "unregistered123",
-		Date:     "2025-06-04",
-		Data:     [96]float64{},
+		Version:      1,
+		ZigbeeID:     "unregistered123",
+		Date:         "2025-06-04",
+		TimezoneName: "Vienna/Europe",
+		Data:         data,
 	}
 	body, _ := json.Marshal(energy)
 	req := httptest.NewRequest("POST", "/api/energy", bytes.NewBuffer(body))
@@ -76,20 +87,29 @@ func TestHandleEnergyData_Valid(t *testing.T) {
 	influxMock.On("WritePoint", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 	dbMock.On("SetReportStatus", "registered123", "2025-06-04", "valid").Return(nil)
 	dbMock.On("GetReportStatus", "registered123", "2025-06-04").Return("", nil)
+	influxMock.On("GetLastPoint", mock.Anything, mock.Anything, mock.Anything).Return(&influxdb.LastPointResult{
+		Fields:    map[string]interface{}{"kW/h": 0.0},
+		Tags:      map[string]string{"zigbee_id": "registered123"},
+		Timestamp: time.Now().UTC(),
+	}, nil)
 
 	_, mux := setupEnergyTestServer(t, plmntMock, influxMock, dbMock)
 
 	// Use a fully increasing array for valid test
-	var increasingData [96]float64
+	var increasingData [96]model.EnergyTuple
 	for i := 0; i < 96; i++ {
-		increasingData[i] = float64(i)
+		increasingData[i] = model.EnergyTuple{
+			Value:     float64(i),
+			Timestamp: model.TimeStamp(time.Now().UTC()),
+		}
 	}
 
 	energy := model.EnergyData{
-		Version:  1,
-		ZigbeeID: "registered123",
-		Date:     "2025-06-04",
-		Data:     increasingData,
+		Version:      1,
+		ZigbeeID:     "registered123",
+		Date:         "2025-06-04",
+		TimezoneName: "Vienna/Europe",
+		Data:         increasingData,
 	}
 	body, _ := json.Marshal(energy)
 	req := httptest.NewRequest("POST", "/api/energy", bytes.NewBuffer(body))
@@ -152,9 +172,20 @@ func TestDownloadEnergyData_CrowdedFile(t *testing.T) {
 	assert.NoError(t, err)
 	defer func() { _ = os.Remove(tempFile.Name()) }()
 
+	var data1, data2 [96]model.EnergyTuple
+	for i := 0; i < 96; i++ {
+		data1[i] = model.EnergyTuple{
+			Value:     1,
+			Timestamp: model.TimeStamp(time.Now().UTC()),
+		}
+		data2[i] = model.EnergyTuple{
+			Value:     4,
+			Timestamp: model.TimeStamp(time.Now().UTC()),
+		}
+	}
 	entries := []model.EnergyData{
-		{Version: 1, ZigbeeID: "id1", Date: "2025-06-04", Data: [96]float64{1, 2, 3}},
-		{Version: 1, ZigbeeID: "id2", Date: "2025-06-05", Data: [96]float64{4, 5, 6}},
+		{Version: 1, ZigbeeID: "id1", Date: "2025-06-04", TimezoneName: "Vienna/Europe", Data: data1},
+		{Version: 1, ZigbeeID: "id2", Date: "2025-06-05", TimezoneName: "Vienna/Europe", Data: data2},
 	}
 	enc := json.NewEncoder(tempFile)
 	for _, e := range entries {
@@ -204,4 +235,119 @@ func TestDownloadEnergyData_CorruptedFile(t *testing.T) {
 	mux.ServeHTTP(rr, req)
 	assert.Equal(t, http.StatusInternalServerError, rr.Code)
 	assert.Contains(t, rr.Body.String(), "Failed to decode data file")
+}
+
+func TestHandleEnergyData_IncrementalVsLastPoint(t *testing.T) {
+	plmntMock := &planetmint.MockPlanetmintClient{}
+	influxMock := &influxdb.MockClient{}
+	dbMock := &database.MockDatabase{}
+	plmntMock.On("IsZigbeeRegistered", "zigbeeInc").Return(true, nil)
+	dbMock.On("SetReportStatus", "zigbeeInc", "2025-06-04", "valid").Return(nil)
+	dbMock.On("GetReportStatus", "zigbeeInc", "2025-06-04").Return("", nil)
+	influxMock.On("WritePoint", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+	influxMock.On("GetLastPoint", mock.Anything, mock.Anything, mock.Anything).Return(&influxdb.LastPointResult{
+		Fields:    map[string]interface{}{"kW/h": 10.0},
+		Tags:      map[string]string{"zigbee_id": "zigbeeInc"},
+		Timestamp: time.Now().UTC(),
+	}, nil)
+
+	_, mux := setupEnergyTestServer(t, plmntMock, influxMock, dbMock)
+	var data [96]model.EnergyTuple
+	for i := 0; i < 96; i++ {
+		data[i] = model.EnergyTuple{
+			Value:     10.0 + float64(i+1), // strictly increasing
+			Timestamp: model.TimeStamp(time.Now().UTC()),
+		}
+	}
+	energy := model.EnergyData{
+		Version:      1,
+		ZigbeeID:     "zigbeeInc",
+		Date:         "2025-06-04",
+		TimezoneName: "Vienna/Europe",
+		Data:         data,
+	}
+	body, _ := json.Marshal(energy)
+	req := httptest.NewRequest("POST", "/api/energy", bytes.NewBuffer(body))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, req)
+	assert.Equal(t, http.StatusOK, rr.Code)
+	assert.Contains(t, rr.Body.String(), "Energy data received and written to database successfully")
+}
+
+func TestHandleEnergyData_EqualVsLastPoint(t *testing.T) {
+	plmntMock := &planetmint.MockPlanetmintClient{}
+	influxMock := &influxdb.MockClient{}
+	dbMock := &database.MockDatabase{}
+	plmntMock.On("IsZigbeeRegistered", "zigbeeEq").Return(true, nil)
+	dbMock.On("SetReportStatus", "zigbeeEq", "2025-06-04", "valid").Return(nil)
+	dbMock.On("GetReportStatus", "zigbeeEq", "2025-06-04").Return("", nil)
+	influxMock.On("WritePoint", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+	influxMock.On("GetLastPoint", mock.Anything, mock.Anything, mock.Anything).Return(&influxdb.LastPointResult{
+		Fields:    map[string]interface{}{"kW/h": 10.0},
+		Tags:      map[string]string{"zigbee_id": "zigbeeEq"},
+		Timestamp: time.Now().UTC(),
+	}, nil)
+
+	_, mux := setupEnergyTestServer(t, plmntMock, influxMock, dbMock)
+	var data [96]model.EnergyTuple
+	for i := 0; i < 96; i++ {
+		data[i] = model.EnergyTuple{
+			Value:     10.0, // equal to last point
+			Timestamp: model.TimeStamp(time.Now().UTC()),
+		}
+	}
+	energy := model.EnergyData{
+		Version:      1,
+		ZigbeeID:     "zigbeeEq",
+		Date:         "2025-06-04",
+		TimezoneName: "Vienna/Europe",
+		Data:         data,
+	}
+	body, _ := json.Marshal(energy)
+	req := httptest.NewRequest("POST", "/api/energy", bytes.NewBuffer(body))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, req)
+	// Expect error or rejection (status code depends on your handler logic)
+	assert.Equal(t, http.StatusOK, rr.Code)
+	assert.Contains(t, rr.Body.String(), "Energy data received and written to database successfull")
+}
+
+func TestHandleEnergyData_LowerVsLastPoint(t *testing.T) {
+	plmntMock := &planetmint.MockPlanetmintClient{}
+	influxMock := &influxdb.MockClient{}
+	dbMock := &database.MockDatabase{}
+	plmntMock.On("IsZigbeeRegistered", "zigbeeLow").Return(true, nil)
+	dbMock.On("SetReportStatus", "zigbeeLow", "2025-06-04", "valid").Return(nil)
+	dbMock.On("GetReportStatus", "zigbeeLow", "2025-06-04").Return("", nil)
+	influxMock.On("WritePoint", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+	influxMock.On("GetLastPoint", mock.Anything, mock.Anything, mock.Anything).Return(&influxdb.LastPointResult{
+		Fields:    map[string]interface{}{"kW/h": 10.0},
+		Tags:      map[string]string{"zigbee_id": "zigbeeLow"},
+		Timestamp: time.Now().UTC(),
+	}, nil)
+
+	_, mux := setupEnergyTestServer(t, plmntMock, influxMock, dbMock)
+	var data [96]model.EnergyTuple
+	for i := 0; i < 96; i++ {
+		data[i] = model.EnergyTuple{
+			Value:     9.0, // lower than last point
+			Timestamp: model.TimeStamp(time.Now().UTC()),
+		}
+	}
+	energy := model.EnergyData{
+		Version:      1,
+		ZigbeeID:     "zigbeeLow",
+		Date:         "2025-06-04",
+		TimezoneName: "Vienna/Europe",
+		Data:         data,
+	}
+	body, _ := json.Marshal(energy)
+	req := httptest.NewRequest("POST", "/api/energy", bytes.NewBuffer(body))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, req)
+	assert.NotEqual(t, http.StatusOK, rr.Code)
+	assert.Contains(t, rr.Body.String(), "Incompatible data: data does not increase")
 }

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/rddl-network/energy-service/internal/config"
 	"github.com/rddl-network/energy-service/internal/database"
@@ -34,6 +35,11 @@ func TestHandleEnergyData(t *testing.T) {
 	dbMock.On("SetReportStatus", "12345", "2025-05-14", "invalid").Return(nil)
 	// Add mock expectation for GetReportStatus (no report exists yet)
 	dbMock.On("GetReportStatus", "12345", "2025-05-14").Return("", nil)
+	influxMock.On("GetLastPoint", mock.Anything, mock.Anything, mock.Anything).Return(&influxdb.LastPointResult{
+		Fields:    map[string]interface{}{"kW/h": 0.0},
+		Tags:      map[string]string{"zigbee_id": "12345"},
+		Timestamp: time.Now().UTC(),
+	}, nil)
 
 	srv, err := server.NewServer(plmntMock, influxMock, dbMock)
 	if err != nil {
@@ -45,11 +51,19 @@ func TestHandleEnergyData(t *testing.T) {
 	srv.Routes(mux)
 
 	// Create a sample energy data payload
+	var data [96]model.EnergyTuple
+	for i := 0; i < 10; i++ {
+		data[i] = model.EnergyTuple{
+			Value:     float64(i + 1),
+			Timestamp: model.TimeStamp(time.Now().UTC()), // Use a fixed or test value if needed
+		}
+	}
 	payload := model.EnergyData{
-		Version:  1,
-		ZigbeeID: "12345",
-		Date:     "2025-05-14",
-		Data:     [96]float64{1, 2, 3, 4, 5},
+		Version:      1,
+		ZigbeeID:     "12345",
+		Date:         "2025-05-14",
+		TimezoneName: "Vienna/Europe",
+		Data:         data,
 	}
 
 	// Marshal the payload to JSON
@@ -92,7 +106,11 @@ func TestHandleEnergyData_ValidIncreasing(t *testing.T) {
 	plmntMock.On("IsZigbeeRegistered", "incrid").Return(true, nil)
 	dbMock.On("SetReportStatus", "incrid", "2025-06-04", "valid").Return(nil)
 	dbMock.On("GetReportStatus", "incrid", "2025-06-04").Return("", nil)
-
+	influxMock.On("GetLastPoint", mock.Anything, mock.Anything, mock.Anything).Return(&influxdb.LastPointResult{
+		Fields:    map[string]interface{}{"kW/h": 0.0},
+		Tags:      map[string]string{"zigbee_id": "incrid"},
+		Timestamp: time.Now().UTC(),
+	}, nil)
 	srv, err := server.NewServer(plmntMock, influxMock, dbMock)
 	if err != nil {
 		t.Fatalf("Failed to create server: %v", err)
@@ -102,15 +120,19 @@ func TestHandleEnergyData_ValidIncreasing(t *testing.T) {
 	mux := http.NewServeMux()
 	srv.Routes(mux)
 
-	var increasing [96]float64
+	var increasing [96]model.EnergyTuple
 	for i := 0; i < 96; i++ {
-		increasing[i] = float64(i)
+		increasing[i] = model.EnergyTuple{
+			Value:     float64(i),
+			Timestamp: model.TimeStamp(time.Now().UTC()),
+		}
 	}
 	payload := model.EnergyData{
-		Version:  1,
-		ZigbeeID: "incrid",
-		Date:     "2025-06-04",
-		Data:     increasing,
+		Version:      1,
+		ZigbeeID:     "incrid",
+		Date:         "2025-06-04",
+		TimezoneName: "Vienna/Europe",
+		Data:         increasing,
 	}
 	jsonPayload, err := json.Marshal(payload)
 	if err != nil {
@@ -144,6 +166,11 @@ func TestHandleEnergyData_AlreadyExists(t *testing.T) {
 	influxMock.On("Close").Return()
 	plmntMock.On("IsZigbeeRegistered", "dupeid").Return(true, nil)
 	dbMock.On("GetReportStatus", "dupeid", "2025-06-05").Return("valid", nil)
+	influxMock.On("GetLastPoint", mock.Anything, mock.Anything, mock.Anything).Return(&influxdb.LastPointResult{
+		Fields:    map[string]interface{}{"kW/h": 0.0},
+		Tags:      map[string]string{"zigbee_id": "dupeid"},
+		Timestamp: time.Now().UTC(),
+	}, nil)
 
 	srv, err := server.NewServer(plmntMock, influxMock, dbMock)
 	if err != nil {
@@ -154,15 +181,19 @@ func TestHandleEnergyData_AlreadyExists(t *testing.T) {
 	mux := http.NewServeMux()
 	srv.Routes(mux)
 
-	var increasing [96]float64
+	var increasing [96]model.EnergyTuple
 	for i := 0; i < 96; i++ {
-		increasing[i] = float64(i)
+		increasing[i] = model.EnergyTuple{
+			Value:     float64(i),
+			Timestamp: model.TimeStamp(time.Now().UTC()),
+		}
 	}
 	payload := model.EnergyData{
-		Version:  1,
-		ZigbeeID: "dupeid",
-		Date:     "2025-06-05",
-		Data:     increasing,
+		Version:      1,
+		ZigbeeID:     "dupeid",
+		Date:         "2025-06-05",
+		TimezoneName: "Vienna/Europe",
+		Data:         increasing,
 	}
 	jsonPayload, err := json.Marshal(payload)
 	if err != nil {


### PR DESCRIPTION
* extended /api/energy to take timestamp, value objects
* added test cases
* create a clear influxdb client object interface
* added increaseing value validation for a given object
* using buket name instead of ID from now on as this is compatible for the query and write client of influxdb